### PR TITLE
0.0.9: Use NodeIndex through out the code to consolidate the node index operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Use NodeIndex through out the code to consolidate the node
 index operation:
 
 - Define NodeIndexRange, aka LevelRange, as Range<NodeIndex>
+- Use the NodeIndexRange for MerkleProof
+- Use the NodeIndexRange for MerkleTree
 
 # Version 0.0.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 Use NodeIndex through out the code to consolidate the node
 index operation:
 
-- Define NodeIndexRange, aka LevelRange, as Range<NodeIndex>
-- Use the NodeIndexRange for MerkleProof
-- Use the NodeIndexRange for MerkleTree
+- Define NodeIndexRange, aka LevelRange, as Range<NodeIndex>.
+- Use NodeIndexRange in MerkleProof.
+- Use NodeIndexRange in MerkleTree.
+- Use NodeIndex in MerkleLeavesMut.
 
 # Version 0.0.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ index operation:
 - Use NodeIndexRange in MerkleProof.
 - Use NodeIndexRange in MerkleTree.
 - Use NodeIndex in MerkleLeavesMut.
+- Add NodeIndex::index() for the array indexing.
 
 # Version 0.0.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 0.0.9
+
+Use NodeIndex through out the code to consolidate the node
+index operation:
+
+- Define NodeIndexRange, aka LevelRange, as Range<NodeIndex>
+
 # Version 0.0.8
 
 - Benchmark MerkleTree::proof() and MerkleProof::verify().

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "merkle-lite"
 # When publishing a new version:
 # - Update CHANGELOG.md
-version = "0.0.8"
+version = "0.0.9"
 edition = "2021"
 rust-version = "1.66"
 authors = ["Keith Noguchi <keith@noguchi.us>"]


### PR DESCRIPTION
- Define NodeIndexRange, aka LevelRange, as Range<NodeIndex>.
- Use NodeIndexRange in MerkleProof.
- Use NodeIndexRange in MerkleTree.
- Use NodeIndex in MerkleLeavesMut.
- Add NodeIndex::index() for the array indexing.
