### PR TITLE
0.0.11: Fix the odd length leaf handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Version 0.0.11
 
-- Cover all the MerkleTree public APIs.
+- Fix the odd length leaf handling.
 
 # Version 0.0.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.0.11
+
+- Cover all the MerkleTree public APIs.
+
 # Version 0.0.10
 
 - Converts the existing tests into macros to cover

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "merkle-lite"
 # When publishing a new version:
 # - Update CHANGELOG.md
-version = "0.0.10"
+version = "0.0.11"
 edition = "2021"
 rust-version = "1.66"
 authors = ["Keith Noguchi <keith@noguchi.us>"]

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ use sha3::Sha3_256;
 
 use merkle_lite::MerkleTree;
 
-// 100 random leaves.
-let leaves: Vec<_> = std::iter::repeat([0u8; 32])
+// Composes MerkleTree from the 100 random leaves.
+let tree: MerkleTree<Sha3_256> = std::iter::repeat([0u8; 32])
     .map(|mut leaf| {
         rand_core::OsRng.fill_bytes(&mut leaf);
         leaf
@@ -31,18 +31,16 @@ let leaves: Vec<_> = std::iter::repeat([0u8; 32])
     .take(100)
     .collect();
 
-// A Merkle tree composed from the leaves.
-let tree: MerkleTree<Sha3_256> = leaves.iter().collect();
-
-// A proof of inclusion for an arbitrary number of leaves
-// specified by the 0-indexed ordered indices.
-let proof = tree.proof(&[12, 98]).unwrap();
-
-// verify the merkle proof of inclusion by comparing the
-// result to the Merkle root.
-let inclusion = vec![(98, &leaves[98]), (12, &leaves[12])];
+// Verifies the proof of inclusion, 12th and 98th leaves.
 assert_eq!(
-    proof.verify(&inclusion).unwrap().as_ref(),
+    tree.proof(&[12, 98])
+        .unwrap()
+        .verify(&[
+            (98, tree.leaves().nth(98).unwrap()),
+            (12, tree.leaves().nth(12).unwrap()),
+        ])
+        .unwrap()
+        .as_ref(),
     tree.root(),
 );
 ```

--- a/benches/tree_from_iter.rs
+++ b/benches/tree_from_iter.rs
@@ -43,7 +43,7 @@ where
     <N as ArrayLength<u8>>::ArrayType: Copy,
     <<B as OutputSizeUser>::OutputSize as ArrayLength<u8>>::ArrayType: Copy,
 {
-    let leaves = [GenericArray::<u8, N>::default(); NR_LEAVES];
+    let leaves = vec![GenericArray::<u8, N>::default(); NR_LEAVES];
 
     b.iter(|| {
         // compose the Merkle tree from the leaves.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,15 @@
 //! A binary Merkle tree and proof.
 //!
+//! [merkle tree and proof]: https://en.wikipedia.org/wiki/Merkle_tree
+//! [rust crypto]: https://github.com/RustCrypto
+//!
 //! A simple, fast, and composable binary [Merkle tree and proof] for
 //! [Rust Crypto] hash functions.
 //!
 //! # Examples
+//!
+//! [`merkletree`]: struct.MerkleTree.html
+//! [`merkleproof`]: struct.MerkleProof.html
 //!
 //! Here is how to compose [`MerkleTree`] and [`MerkleProof`] for the
 //! proof of inclusion verification:
@@ -14,8 +20,8 @@
 //!
 //! use merkle_lite::MerkleTree;
 //!
-//! // 100 random leaves.
-//! let leaves: Vec<_> = std::iter::repeat([0u8; 32])
+//! // Composes MerkleTree from the 100 random leaves.
+//! let tree: MerkleTree<Sha3_256> = std::iter::repeat([0u8; 32])
 //!     .map(|mut leaf| {
 //!         rand_core::OsRng.fill_bytes(&mut leaf);
 //!         leaf
@@ -23,30 +29,19 @@
 //!     .take(100)
 //!     .collect();
 //!
-//! // A Merkle tree composed from the leaves.
-//! let tree: MerkleTree<Sha3_256> = leaves.iter().collect();
-//!
-//! // A proof of inclusion for an arbitrary number of leaves
-//! // specified by the 0-indexed ordered indices.
-//! let proof = tree.proof(&[0, 1, 42, 98]).unwrap();
-//!
-//! // verify the merkle proof of inclusion by comparing the
-//! // result to the Merkle root.
-//! let inclusion = vec![
-//!     (98, &leaves[98]),
-//!     (1, &leaves[1]),
-//!     (42, &leaves[42]),
-//!     (0, &leaves[0])
-//! ];
+//! // Verifies the proof of inclusion, e.g. 12th and 98th leaves.
 //! assert_eq!(
-//!     proof.verify(&inclusion).unwrap().as_ref(),
+//!     tree.proof(&[12, 98])
+//!         .unwrap()
+//!         .verify(&[
+//!             (98, tree.leaves().nth(98).unwrap()),
+//!             (12, tree.leaves().nth(12).unwrap()),
+//!         ])
+//!         .unwrap()
+//!         .as_ref(),
 //!     tree.root(),
 //! );
 //! ```
-//! [merkle tree and proof]: https://en.wikipedia.org/wiki/Merkle_tree
-//! [rust crypto]: https://github.com/RustCrypto
-//! [`merkletree`]: struct.MerkleTree.html
-//! [`merkleproof`]: struct.MerkleProof.html
 
 #![no_std]
 #![forbid(unsafe_code, missing_docs, missing_debug_implementations)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,11 +126,6 @@ where
             return tree;
         }
 
-        // make it even leaves.
-        if tree.leaf_range.is_odd_len() {
-            tree.push(tree.data[tree.leaf_range.end().index() - 1].clone());
-        }
-
         // calculate the Merkle root.
         for _ in tree.merkle_root_iter(tree.leaf_range.clone()) {}
 
@@ -194,10 +189,10 @@ where
     /// use merkle_lite::MerkleTree;
     /// use sha3::Sha3_256;
     ///
-    /// let leaves = [[0u8; 32]; 100];
+    /// let leaves = [[0u8; 32]; 127];
     /// let tree: MerkleTree<Sha3_256> = leaves.into_iter().collect();
     ///
-    /// assert_eq!(tree.leaf_len(), 100);
+    /// assert_eq!(tree.leaf_len(), 127);
     /// ```
     pub const fn leaf_len(&self) -> usize {
         self.leaf_range.len()
@@ -394,12 +389,10 @@ where
         Some(proof)
     }
 
-    fn with_leaf_len(leaf_len: usize) -> Self {
-        let total_len = match leaf_len.count_ones() {
+    fn with_leaf_len(mut leaf_len: usize) -> Self {
+        let total_len = match leaf_len {
             0 => 0,
-            1 => {
-                // power of two leaves.
-                //
+            leaf_len if leaf_len.is_power_of_two() => {
                 // The following equasion will give us the entire
                 // tree size, as `leaf_len - 1` represents the
                 // size of the base tree.
@@ -410,6 +403,11 @@ where
                 // calculate the tree capacity in addition to the actual
                 // leaf length.
                 let base = 1 << (usize::BITS - leaf_len.leading_zeros() - 1);
+                // make the `leaf_len` even for the additional space
+                // to copy the last element to have a even leafs.
+                if leaf_len & 0b1 == 0b1 {
+                    leaf_len += 1
+                }
                 (2 * base - 1) + leaf_len
             }
         };
@@ -431,10 +429,31 @@ where
     }
 
     fn merkle_root_iter(&mut self, updated_leaf_range: NodeIndexRange) -> MerkleRootIter<B> {
+        // Makes the start and end indices to be odd to cover the valid range.
+        let start = match updated_leaf_range.start() {
+            start if !start.is_root() && start.is_even() => start - 1,
+            start => start,
+        };
+        let end = match updated_leaf_range.end() {
+            end if end.is_even() => {
+                // In case the odd length leaf,
+                if end == self.leaf_range.end() {
+                    // pushes the last hash in the end without updating
+                    // the `leaf_range`.
+                    //
+                    // This is safe as we allocate even number of nodes
+                    // in `with_leaf_len`.
+                    self.data[self.leaf_range.end().index()] =
+                        self.data[self.leaf_range.end().index() - 1].clone();
+                }
+                end + 1
+            }
+            end => end,
+        };
         MerkleRootIter {
-            data: &mut self.data[..updated_leaf_range.end().index()],
+            data: &mut self.data[..end.index()],
             level_range: self.leaf_range.clone(),
-            updated_range: updated_leaf_range,
+            updated_range: NodeIndexRange(start..end),
         }
     }
 
@@ -499,23 +518,14 @@ where
 {
     /// Calculates the Merkle root in case there is a change in the leaves.
     fn drop(&mut self) {
-        // do nothing in case of no change.
+        // do nothing in case of no changes.
         if self.mutated_set.is_empty() {
             return;
         }
-        // get the range of the change set.
-        let start = match self.mutated_set.first() {
-            Some(&start) if !start.is_root() && start.is_even() => start - 1,
-            Some(&start) => start,
-            None => return,
-        };
-        let end = match self.mutated_set.last() {
-            Some(&end) if end.is_even() => end + 1,
-            Some(&end) => end,
-            None => return,
-        };
         // calculate the Merkle root.
-        for _ in self.tree.merkle_root_iter(NodeIndexRange(start..end)) {}
+        let start = self.mutated_set.first().unwrap();
+        let end = self.mutated_set.last().unwrap();
+        for _ in self.tree.merkle_root_iter(NodeIndexRange(*start..*end)) {}
     }
 }
 
@@ -889,12 +899,6 @@ impl NodeIndexRange {
     #[inline]
     const fn is_empty(&self) -> bool {
         self.len() == 0
-    }
-
-    /// Returns `true` if the range is odd length.
-    #[inline]
-    const fn is_odd_len(&self) -> bool {
-        self.len() & 0b1 == 0b1
     }
 
     /// Returns `start` value.

--- a/tests/tree_get_leaves_mut.rs
+++ b/tests/tree_get_leaves_mut.rs
@@ -26,7 +26,6 @@ macro_rules! test_tree_get_leaves_mut {
 
                     {
                         // Updates all the leaves with the provided hash value.
-                        let leaf_len = tree.leaf_len();
                         let mut leaves_mut = tree.get_leaves_mut();
                         for i in 0..leaf_len {
                             leaves_mut[i] = $single_leaf_hash.into();

--- a/tests/tree_leaf_len.rs
+++ b/tests/tree_leaf_len.rs
@@ -10,36 +10,14 @@ macro_rules! test_tree_leaf_len {
             use merkle_lite::MerkleTree;
 
             #[test]
-            fn tree_leaf_len_single() {
-                let leaves = [GenericArray::<u8, $hash_size>::default(); 1];
-
-                let tree: MerkleTree<$hasher> = leaves.iter().collect();
-                assert_eq!(tree.leaf_len(), 1);
-            }
-
-            #[test]
             fn tree_leaf_len_even() {
-                for leaf_len in (0..200).step_by(2) {
+                for leaf_len in (0..200) {
                     let tree: MerkleTree<$hasher> =
                         iter::repeat(GenericArray::<u8, $hash_size>::default())
                             .take(leaf_len)
                             .collect();
 
                     assert_eq!(tree.leaf_len(), leaf_len);
-                }
-            }
-
-            #[test]
-            fn tree_leaf_len_odd() {
-                for leaf_len in (3..200).step_by(2) {
-                    let tree: MerkleTree<$hasher> =
-                        iter::repeat(GenericArray::<u8, $hash_size>::default())
-                            .take(leaf_len)
-                            .collect();
-
-                    // MerkleTree copies the last element of the leaf to
-                    // make it the even leaves.
-                    assert_eq!(tree.leaf_len(), leaf_len + 1);
                 }
             }
         }


### PR DESCRIPTION
Changing the actual tree length to even is
misleading and the error prone, especially
when we support the Extend trait in the near
future.

Instead, MerkleTree allocate the additional
element in the vector and just copy the value
during the Merkle root calculation.