### PR TITLE
0.0.12: Make the data order leaf to root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Version 0.0.12
+
+- Make the data order from root-to-leaf to leaf-to-root
+  1. It only allocates the required number of nodes
+  2. It makes the level iteration much easier to make.
+
+It also dropped leaf_capacity API, as there is
+no leaf node specific capacity anymore.
+
 # Version 0.0.11
 
 - Fix the odd length leaf handling.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "merkle-lite"
 # When publishing a new version:
 # - Update CHANGELOG.md
-version = "0.0.11"
+version = "0.0.12"
 edition = "2021"
 rust-version = "1.66"
 authors = ["Keith Noguchi <keith@noguchi.us>"]

--- a/README.md
+++ b/README.md
@@ -22,26 +22,27 @@ use sha3::Sha3_256;
 
 use merkle_lite::MerkleTree;
 
-// Composes MerkleTree from the 100 random leaves.
+// Composes MerkleTree with the 50,000 random leaves.
 let tree: MerkleTree<Sha3_256> = std::iter::repeat([0u8; 32])
     .map(|mut leaf| {
         rand_core::OsRng.fill_bytes(&mut leaf);
         leaf
     })
-    .take(100)
+    .take(50_000)
     .collect();
 
-// Verifies the proof of inclusion, 12th and 98th leaves.
+// Verifies the proof of inclusion for the particular leaves.
+let leaf_indices = [12, 0, 1, 1201, 13_903, 980];
+let leaf_hashes: Vec<_> = leaf_indices
+    .iter().map(|index| (*index, tree.leaves().nth(*index).expect("leaf")))
+    .collect();
 assert_eq!(
-    tree.proof(&[12, 98])
-        .unwrap()
-        .verify(&[
-            (98, tree.leaves().nth(98).unwrap()),
-            (12, tree.leaves().nth(12).unwrap()),
-        ])
-        .unwrap()
+    tree.proof(&leaf_indices)
+        .expect("proof")
+        .verify(&leaf_hashes)
+        .expect("verify")
         .as_ref(),
-    tree.root(),
+    tree.root().expect("root"),
 );
 ```
 

--- a/benches/proof_verify.rs
+++ b/benches/proof_verify.rs
@@ -57,10 +57,13 @@ where
 
     b.iter(|| {
         // verify the Merkle root for the proof of inclusion.
-        assert!(tree
-            .proof(&proof_leaf_indices)
-            .unwrap()
-            .verify(&proof_leaf_hashes)
-            .is_some());
+        assert_eq!(
+            tree.proof(&proof_leaf_indices)
+                .unwrap()
+                .verify(&proof_leaf_hashes)
+                .unwrap()
+                .as_ref(),
+            tree.root().unwrap(),
+        );
     })
 }

--- a/tests/tree_depth.rs
+++ b/tests/tree_depth.rs
@@ -1,4 +1,4 @@
-/// Tests `MerkleTree::leaf_len()`.
+/// Tests `MerkleTree::depth()`.
 macro_rules! test_tree_leaf_len {
     ($mod:ident, $hash_size:ty, $hasher:ty) => {
         mod $mod {
@@ -10,15 +10,28 @@ macro_rules! test_tree_leaf_len {
             use merkle_lite::MerkleTree;
 
             #[test]
-            fn tree_leaf_len() {
-                for leaf_len in 0..200 {
+            fn tree_depth() {
+                vec![
+                    (0, 0),
+                    (1, 1),
+                    (2, 2),
+                    (3, 3),
+                    (4, 3),
+                    (5, 4),
+                    (6, 4),
+                    (7, 4),
+                    (8, 4),
+                    (9, 5),
+                ]
+                .into_iter()
+                .for_each(|(leaf_len, tree_depth)| {
                     let tree: MerkleTree<$hasher> =
                         iter::repeat(GenericArray::<u8, $hash_size>::default())
                             .take(leaf_len)
                             .collect();
 
-                    assert_eq!(tree.leaf_len(), leaf_len);
-                }
+                    assert_eq!(tree.depth(), tree_depth, "leaf_len={leaf_len}");
+                });
             }
         }
     };

--- a/tests/tree_get_leaves_mut.rs
+++ b/tests/tree_get_leaves_mut.rs
@@ -1,6 +1,6 @@
 /// Tests `MerkleTree::get_leaves_mut()`.
 ///
-/// Identical leaves to keep the number of Merkle root sane.
+/// Identical leaves to keep the number of Merkle root manageable.
 macro_rules! test_tree_get_leaves_mut {
     ($mod:ident, $hash_len:ty, $hasher:ty, $single_leaf_hash:expr, $merkle_root_in_depth:expr) => {
         mod $mod {
@@ -33,9 +33,8 @@ macro_rules! test_tree_get_leaves_mut {
                     }
 
                     // Tests the Markle root.
-                    let root = tree.root();
+                    let root = tree.root().unwrap();
                     let depth = tree.depth();
-
                     assert_eq!(
                         root, merkle_root_in_depth[&depth],
                         "leaf_len={leaf_len}, tree_depth={depth}, tree_root={root:02x?}",

--- a/tests/tree_len.rs
+++ b/tests/tree_len.rs
@@ -1,0 +1,40 @@
+/// Tests `MerkleTree::len()`.
+macro_rules! test_tree_leaf_len {
+    ($mod:ident, $hash_size:ty, $hasher:ty) => {
+        mod $mod {
+            use std::iter;
+
+            use digest::generic_array::GenericArray;
+            use digest::typenum;
+
+            use merkle_lite::MerkleTree;
+
+            #[test]
+            fn tree_len() {
+                vec![
+                    (0, 0),
+                    (1, 1),
+                    (2, 2 + 1),
+                    (3, 3 + 2 + 1),
+                    (4, 4 + 2 + 1),
+                    (5, 5 + 3 + 2 + 1),
+                    (6, 6 + 3 + 2 + 1),
+                    (7, 7 + 4 + 2 + 1),
+                    (8, 8 + 4 + 2 + 1),
+                    (9, 9 + 5 + 3 + 2 + 1),
+                ]
+                .into_iter()
+                .for_each(|(leaf_len, tree_len)| {
+                    let tree: MerkleTree<$hasher> =
+                        iter::repeat(GenericArray::<u8, $hash_size>::default())
+                            .take(leaf_len)
+                            .collect();
+
+                    assert_eq!(tree.len(), tree_len, "leaf_len={leaf_len}");
+                });
+            }
+        }
+    };
+}
+
+test_tree_leaf_len!(sha2_224, typenum::U28, sha2::Sha224);

--- a/tests/tree_proof_verify.rs
+++ b/tests/tree_proof_verify.rs
@@ -1,0 +1,372 @@
+/// Tests `MerkleTree::proof()` and MerkleProof::verify()`.
+macro_rules! test_tree_proof_verify {
+    ($mod:ident, $hash_size:ty, $hasher:ty, $leaf_len:expr, $leaf_indices:expr) => {
+        mod $mod {
+            use std::iter;
+
+            use digest::generic_array::GenericArray;
+            use digest::typenum;
+            use rand_core::RngCore;
+
+            use merkle_lite::MerkleTree;
+
+            #[test]
+            fn tree_proof_verify() {
+                // Create a Merkle tree.
+                let tree: MerkleTree<$hasher> =
+                    iter::repeat(GenericArray::<u8, $hash_size>::default())
+                        .take($leaf_len)
+                        .map(|mut leaf| {
+                            rand_core::OsRng.fill_bytes(&mut leaf);
+                            leaf
+                        })
+                        .collect();
+
+                // Tests the Merkle root.
+                let leaf_indices: Vec<_> = $leaf_indices.into_iter().flatten().collect();
+                let leaf_hash: Vec<_> = leaf_indices
+                    .iter()
+                    .map(|index| (*index, tree.leaves().nth(*index).unwrap()))
+                    .collect();
+                assert_eq!(
+                    tree.proof(&leaf_indices)
+                        .expect("proof")
+                        .verify(&leaf_hash)
+                        .expect("verify")
+                        .as_ref(),
+                    tree.root().expect("root"),
+                );
+            }
+        }
+    };
+}
+
+test_tree_proof_verify!(sha2_256_0001_0, typenum::U32, sha2::Sha256, 1, [0..1]);
+test_tree_proof_verify!(sha3_256_0001_0, typenum::U32, sha3::Sha3_256, 1, [0..1]);
+test_tree_proof_verify!(sha2_256_0002_0, typenum::U32, sha2::Sha256, 2, [0..1]);
+test_tree_proof_verify!(sha3_256_0002_0, typenum::U32, sha3::Sha3_256, 2, [0..1]);
+test_tree_proof_verify!(sha2_256_0002_1, typenum::U32, sha2::Sha256, 2, [1..2]);
+test_tree_proof_verify!(sha3_256_0002_1, typenum::U32, sha3::Sha3_256, 2, [1..2]);
+test_tree_proof_verify!(sha2_256_0002_0_1, typenum::U32, sha2::Sha256, 2, [0..2]);
+test_tree_proof_verify!(sha3_256_0002_0_1, typenum::U32, sha3::Sha3_256, 2, [0..2]);
+test_tree_proof_verify!(sha2_256_0003_0, typenum::U32, sha2::Sha256, 3, [0..1]);
+test_tree_proof_verify!(sha3_256_0003_0, typenum::U32, sha3::Sha3_256, 3, [0..1]);
+test_tree_proof_verify!(sha2_256_0003_1, typenum::U32, sha2::Sha256, 3, [1..2]);
+test_tree_proof_verify!(sha3_256_0003_1, typenum::U32, sha3::Sha3_256, 3, [1..2]);
+test_tree_proof_verify!(sha2_256_0003_2, typenum::U32, sha2::Sha256, 3, [2..3]);
+test_tree_proof_verify!(sha3_256_0003_2, typenum::U32, sha3::Sha3_256, 3, [2..3]);
+test_tree_proof_verify!(sha2_256_0003_0_1, typenum::U32, sha2::Sha256, 3, [0..2]);
+test_tree_proof_verify!(sha3_256_0003_0_1, typenum::U32, sha3::Sha3_256, 3, [0..2]);
+test_tree_proof_verify!(sha2_256_0003_1_2, typenum::U32, sha2::Sha256, 3, [1..3]);
+test_tree_proof_verify!(sha3_256_0003_1_2, typenum::U32, sha3::Sha3_256, 3, [1..3]);
+test_tree_proof_verify!(
+    sha2_256_0003_0_2,
+    typenum::U32,
+    sha2::Sha256,
+    3,
+    [0..1, 2..3]
+);
+test_tree_proof_verify!(
+    sha3_256_0003_0_2,
+    typenum::U32,
+    sha3::Sha3_256,
+    3,
+    [0..1, 2..3]
+);
+test_tree_proof_verify!(sha2_256_0003_0_1_2, typenum::U32, sha2::Sha256, 3, [0..3]);
+test_tree_proof_verify!(sha3_256_0003_0_1_2, typenum::U32, sha3::Sha3_256, 3, [0..3]);
+test_tree_proof_verify!(sha2_256_0004_0, typenum::U32, sha2::Sha256, 4, [0..1]);
+test_tree_proof_verify!(sha3_256_0004_0, typenum::U32, sha3::Sha3_256, 4, [0..1]);
+test_tree_proof_verify!(sha2_256_0004_1, typenum::U32, sha2::Sha256, 4, [1..2]);
+test_tree_proof_verify!(sha3_256_0004_1, typenum::U32, sha3::Sha3_256, 4, [1..2]);
+test_tree_proof_verify!(sha2_256_0004_2, typenum::U32, sha2::Sha256, 4, [2..3]);
+test_tree_proof_verify!(sha3_256_0004_2, typenum::U32, sha3::Sha3_256, 4, [2..3]);
+test_tree_proof_verify!(sha2_256_0004_3, typenum::U32, sha2::Sha256, 4, [3..4]);
+test_tree_proof_verify!(sha3_256_0004_3, typenum::U32, sha3::Sha3_256, 4, [3..4]);
+test_tree_proof_verify!(sha2_256_0004_0_1, typenum::U32, sha2::Sha256, 4, [0..2]);
+test_tree_proof_verify!(sha3_256_0004_0_1, typenum::U32, sha3::Sha3_256, 4, [0..2]);
+test_tree_proof_verify!(sha2_256_0004_1_2, typenum::U32, sha2::Sha256, 4, [1..3]);
+test_tree_proof_verify!(sha3_256_0004_1_2, typenum::U32, sha3::Sha3_256, 4, [1..3]);
+test_tree_proof_verify!(sha2_256_0004_2_3, typenum::U32, sha2::Sha256, 4, [2..4]);
+test_tree_proof_verify!(sha3_256_0004_2_3, typenum::U32, sha3::Sha3_256, 4, [2..4]);
+test_tree_proof_verify!(
+    sha2_256_0004_0_2,
+    typenum::U32,
+    sha2::Sha256,
+    4,
+    [0..1, 2..3]
+);
+test_tree_proof_verify!(
+    sha3_256_0004_0_2,
+    typenum::U32,
+    sha3::Sha3_256,
+    4,
+    [0..1, 2..3]
+);
+test_tree_proof_verify!(
+    sha2_256_0004_1_3,
+    typenum::U32,
+    sha2::Sha256,
+    4,
+    [1..2, 3..4]
+);
+test_tree_proof_verify!(
+    sha3_256_0004_1_3,
+    typenum::U32,
+    sha3::Sha3_256,
+    4,
+    [1..2, 3..4]
+);
+test_tree_proof_verify!(sha2_256_0004_0_1_2, typenum::U32, sha2::Sha256, 4, [0..3]);
+test_tree_proof_verify!(sha3_256_0004_0_1_2, typenum::U32, sha3::Sha3_256, 4, [0..3]);
+test_tree_proof_verify!(sha2_256_0004_1_2_3, typenum::U32, sha2::Sha256, 4, [1..4]);
+test_tree_proof_verify!(sha3_256_0004_1_2_3, typenum::U32, sha3::Sha3_256, 4, [1..4]);
+test_tree_proof_verify!(sha2_256_0004_0_1_2_3, typenum::U32, sha2::Sha256, 4, [0..4]);
+test_tree_proof_verify!(
+    sha3_256_0004_0_1_2_3,
+    typenum::U32,
+    sha3::Sha3_256,
+    4,
+    [0..4]
+);
+test_tree_proof_verify!(sha2_256_0005_0, typenum::U32, sha2::Sha256, 5, [0..1]);
+test_tree_proof_verify!(sha3_256_0005_0, typenum::U32, sha3::Sha3_256, 5, [0..1]);
+test_tree_proof_verify!(sha2_256_0005_1, typenum::U32, sha2::Sha256, 5, [1..2]);
+test_tree_proof_verify!(sha3_256_0005_1, typenum::U32, sha3::Sha3_256, 5, [1..2]);
+test_tree_proof_verify!(sha2_256_0005_2, typenum::U32, sha2::Sha256, 5, [2..3]);
+test_tree_proof_verify!(sha3_256_0005_2, typenum::U32, sha3::Sha3_256, 5, [2..3]);
+test_tree_proof_verify!(sha2_256_0005_3, typenum::U32, sha2::Sha256, 5, [3..4]);
+test_tree_proof_verify!(sha3_256_0005_3, typenum::U32, sha3::Sha3_256, 5, [3..4]);
+test_tree_proof_verify!(sha2_256_0005_4, typenum::U32, sha2::Sha256, 5, [4..5]);
+test_tree_proof_verify!(sha3_256_0005_4, typenum::U32, sha3::Sha3_256, 5, [4..5]);
+test_tree_proof_verify!(sha2_256_0005_0_1, typenum::U32, sha2::Sha256, 5, [0..2]);
+test_tree_proof_verify!(sha3_256_0005_0_1, typenum::U32, sha3::Sha3_256, 5, [0..2]);
+test_tree_proof_verify!(sha2_256_0005_1_2, typenum::U32, sha2::Sha256, 5, [1..3]);
+test_tree_proof_verify!(sha3_256_0005_1_2, typenum::U32, sha3::Sha3_256, 5, [1..3]);
+test_tree_proof_verify!(sha2_256_0005_2_3, typenum::U32, sha2::Sha256, 5, [2..4]);
+test_tree_proof_verify!(sha3_256_0005_2_3, typenum::U32, sha3::Sha3_256, 5, [2..4]);
+test_tree_proof_verify!(sha2_256_0005_3_4, typenum::U32, sha2::Sha256, 5, [3..5]);
+test_tree_proof_verify!(sha3_256_0005_3_4, typenum::U32, sha3::Sha3_256, 5, [3..5]);
+test_tree_proof_verify!(
+    sha2_256_0005_0_2,
+    typenum::U32,
+    sha2::Sha256,
+    5,
+    [0..1, 2..3]
+);
+test_tree_proof_verify!(
+    sha3_256_0005_0_2,
+    typenum::U32,
+    sha3::Sha3_256,
+    5,
+    [0..1, 2..3]
+);
+test_tree_proof_verify!(
+    sha2_256_0005_1_3,
+    typenum::U32,
+    sha2::Sha256,
+    5,
+    [1..2, 3..4]
+);
+test_tree_proof_verify!(
+    sha3_256_0005_1_3,
+    typenum::U32,
+    sha3::Sha3_256,
+    5,
+    [1..2, 3..4]
+);
+test_tree_proof_verify!(
+    sha2_256_0005_2_4,
+    typenum::U32,
+    sha2::Sha256,
+    5,
+    [2..3, 4..5]
+);
+test_tree_proof_verify!(
+    sha3_256_0005_2_4,
+    typenum::U32,
+    sha3::Sha3_256,
+    5,
+    [2..3, 4..5]
+);
+test_tree_proof_verify!(sha2_256_0005_0_1_2, typenum::U32, sha2::Sha256, 5, [0..3]);
+test_tree_proof_verify!(sha3_256_0005_0_1_2, typenum::U32, sha3::Sha3_256, 5, [0..3]);
+test_tree_proof_verify!(sha2_256_0005_1_2_3, typenum::U32, sha2::Sha256, 5, [1..4]);
+test_tree_proof_verify!(sha3_256_0005_1_2_3, typenum::U32, sha3::Sha3_256, 5, [1..4]);
+test_tree_proof_verify!(sha2_256_0005_2_3_4, typenum::U32, sha2::Sha256, 5, [2..5]);
+test_tree_proof_verify!(sha3_256_0005_2_3_4, typenum::U32, sha3::Sha3_256, 5, [2..5]);
+test_tree_proof_verify!(
+    sha2_256_0005_0_2_3,
+    typenum::U32,
+    sha2::Sha256,
+    5,
+    [0..1, 2..4]
+);
+test_tree_proof_verify!(
+    sha3_256_0005_0_2_3,
+    typenum::U32,
+    sha3::Sha3_256,
+    5,
+    [0..1, 2..4]
+);
+test_tree_proof_verify!(
+    sha2_256_0005_0_3_4,
+    typenum::U32,
+    sha2::Sha256,
+    5,
+    [0..1, 3..5]
+);
+test_tree_proof_verify!(
+    sha3_256_0005_0_3_4,
+    typenum::U32,
+    sha3::Sha3_256,
+    5,
+    [0..1, 3..5]
+);
+test_tree_proof_verify!(
+    sha2_256_0005_1_3_4,
+    typenum::U32,
+    sha2::Sha256,
+    5,
+    [1..2, 3..5]
+);
+test_tree_proof_verify!(
+    sha3_256_0005_1_3_4,
+    typenum::U32,
+    sha3::Sha3_256,
+    5,
+    [1..2, 3..5]
+);
+test_tree_proof_verify!(sha2_256_0005_0_1_2_3, typenum::U32, sha2::Sha256, 5, [0..4]);
+test_tree_proof_verify!(
+    sha3_256_0005_0_1_2_3,
+    typenum::U32,
+    sha3::Sha3_256,
+    5,
+    [0..4]
+);
+test_tree_proof_verify!(
+    sha2_256_0005_0_1_3_4,
+    typenum::U32,
+    sha2::Sha256,
+    5,
+    [0..2, 3..5]
+);
+test_tree_proof_verify!(
+    sha3_256_0005_0_1_3_4,
+    typenum::U32,
+    sha3::Sha3_256,
+    5,
+    [0..2, 3..5]
+);
+test_tree_proof_verify!(
+    sha2_256_0005_0_2_3_4,
+    typenum::U32,
+    sha2::Sha256,
+    5,
+    [0..1, 2..5]
+);
+test_tree_proof_verify!(
+    sha3_256_0005_0_2_3_4,
+    typenum::U32,
+    sha3::Sha3_256,
+    5,
+    [0..1, 2..5]
+);
+test_tree_proof_verify!(sha2_256_0005_1_2_3_4, typenum::U32, sha2::Sha256, 5, [1..5]);
+test_tree_proof_verify!(
+    sha3_256_0005_1_2_3_4,
+    typenum::U32,
+    sha3::Sha3_256,
+    5,
+    [1..5]
+);
+test_tree_proof_verify!(
+    sha2_256_0005_0_1_2_3_4,
+    typenum::U32,
+    sha2::Sha256,
+    5,
+    [0..5]
+);
+test_tree_proof_verify!(
+    sha3_256_0005_0_1_2_3_4,
+    typenum::U32,
+    sha3::Sha3_256,
+    5,
+    [0..5]
+);
+
+test_tree_proof_verify!(sha2_256_1000_0, typenum::U32, sha2::Sha256, 1000, [0..1]);
+test_tree_proof_verify!(sha3_256_1000_0, typenum::U32, sha3::Sha3_256, 1000, [0..1]);
+test_tree_proof_verify!(sha2_256_1001_0, typenum::U32, sha2::Sha256, 1001, [0..1]);
+test_tree_proof_verify!(sha3_256_1001_0, typenum::U32, sha3::Sha3_256, 1001, [0..1]);
+test_tree_proof_verify!(
+    sha2_256_1000_999,
+    typenum::U32,
+    sha2::Sha256,
+    1000,
+    [999..1000]
+);
+test_tree_proof_verify!(
+    sha3_256_1000_999,
+    typenum::U32,
+    sha3::Sha3_256,
+    1000,
+    [999..1000]
+);
+test_tree_proof_verify!(
+    sha2_256_1001_1000,
+    typenum::U32,
+    sha2::Sha256,
+    1001,
+    [1000..1001]
+);
+test_tree_proof_verify!(
+    sha3_256_1001_1000,
+    typenum::U32,
+    sha3::Sha3_256,
+    1001,
+    [1000..1001]
+);
+test_tree_proof_verify!(
+    sha2_256_1000_0_999,
+    typenum::U32,
+    sha2::Sha256,
+    1000,
+    [0..1, 999..1000]
+);
+test_tree_proof_verify!(
+    sha3_256_1000_0_999,
+    typenum::U32,
+    sha3::Sha3_256,
+    1000,
+    [0..1, 999..1000]
+);
+test_tree_proof_verify!(
+    sha2_256_1001_0_999,
+    typenum::U32,
+    sha2::Sha256,
+    1001,
+    [0..1, 999..1000]
+);
+test_tree_proof_verify!(
+    sha3_256_1001_0_999,
+    typenum::U32,
+    sha3::Sha3_256,
+    1001,
+    [0..1, 999..1000]
+);
+test_tree_proof_verify!(
+    sha2_256_1001_0_1000,
+    typenum::U32,
+    sha2::Sha256,
+    1001,
+    [0..1, 1000..1001]
+);
+test_tree_proof_verify!(
+    sha3_256_1001_0_1000,
+    typenum::U32,
+    sha3::Sha3_256,
+    1001,
+    [0..1, 1000..1001]
+);

--- a/tests/tree_root.rs
+++ b/tests/tree_root.rs
@@ -21,7 +21,7 @@ macro_rules! test_tree_root {
                         iter::repeat($single_leaf_hash).take(leaf_len).collect();
 
                     // Tests the Merkle root.
-                    let root = tree.root();
+                    let root = tree.root().unwrap();
                     let depth = tree.depth();
                     assert_eq!(
                         root, merkle_root_in_depth[&depth],


### PR DESCRIPTION
Changing the order of the node from root-to-leaf
to leaf-to-root to:

1) only allocates the required number of nodes
2) keeps the code easy to understand

Drops the leaf_capacity method, as there is
only leaf_len node allocated for the leaf.