### PR TITLE
0.0.14: NodeIndexSet to handle batch leaf update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         # When updating this, the reminder to update the minimum supported
         # Rust version in Cargo.toml.
-        rust: ['1.66']
+        rust: ['1.61']
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+# Version 0.0.14
+
+- Improved MerkleLeavesMut update operation with LeftNodeIndexSet.
+
 # Version 0.0.13
 
-- Adds the Merkle proof example
+- Add the Merkle proof example
 
 # Version 0.0.12
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,14 +2,16 @@
 name = "merkle-lite"
 # When publishing a new version:
 # - Update CHANGELOG.md
-version = "0.0.13"
+version = "0.0.14"
 edition = "2021"
-rust-version = "1.66"
+rust-version = "1.61"
 authors = ["Keith Noguchi <keith@noguchi.us>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+homepage = "https://github.com/keithnoguchi/merkle-lite"
 repository = "https://github.com/keithnoguchi/merkle-lite"
-keywords = ["crypto", "hash", "merkle", "merkle-tree", "no-std"]
+documentation = "https://docs.rs/merkle-lite"
+keywords = ["crypto", "merkle", "merkle-tree", "no-std"]
 categories = ["data-structures", "cryptography", "no-std"]
 description = "A simple, fast, and composable binary Merkle tree and proof for Rust Crypto hash functions"
 
@@ -26,6 +28,10 @@ sha3 = "0.10.6"
 
 [[bench]]
 name = "tree_from_iter"
+harness = false
+
+[[bench]]
+name = "tree_get_leaves_mut"
 harness = false
 
 [[bench]]

--- a/README.md
+++ b/README.md
@@ -14,16 +14,15 @@ for [Rust Crypto] hash functions.
 
 ## Examples
 
-Here is how to create `MerkleTree` and `MerkleProof`
-for the ordered array of cryptographic hashes:
+It's super simple to compose `MerkleTree` from the ordered array
+of hashes and verify the proof of inclusion with `MerkleProof`:
+
 ```
-use rand_core::RngCore;
-use sha3::Sha3_256;
-
 use merkle_lite::MerkleTree;
+use rand_core::RngCore;
 
-// Composes a MerkleTree for the 50,000 hashes.
-let tree: MerkleTree<Sha3_256> = std::iter::repeat([0u8; 32])
+// Composes MerkleTree from the 50,000 random hashes.
+let tree: MerkleTree<sha3::Sha3_256> = std::iter::repeat([0u8; 32])
     .map(|mut leaf| {
         rand_core::OsRng.fill_bytes(&mut leaf);
         leaf
@@ -31,10 +30,11 @@ let tree: MerkleTree<Sha3_256> = std::iter::repeat([0u8; 32])
     .take(50_000)
     .collect();
 
-// Verifies the proof of inclusion for the particular leaves.
+// Verifies the proof of inclusion for the arbitrary leaves.
 let leaf_indices = [12, 0, 1, 1201, 13_903, 980];
 let leaf_hashes: Vec<_> = leaf_indices
-    .iter().map(|index| (*index, tree.leaves().nth(*index).expect("leaf")))
+    .iter()
+    .map(|index| (*index, tree.leaves().nth(*index).expect("leaf")))
     .collect();
 assert_eq!(
     tree.proof(&leaf_indices)

--- a/benches/tree_get_leaves_mut.rs
+++ b/benches/tree_get_leaves_mut.rs
@@ -1,0 +1,107 @@
+//! [`MerkleTree::get_leaves_mut`] Benchmark
+//!
+//! [`merkletree::get_leaves_mut`]: https://docs.rs/merkle-lite/latest/merkle_lite/struct.MerkleTree.html#get_leaves_mut
+#[macro_use]
+extern crate bencher;
+
+use bencher::Bencher;
+
+use digest::generic_array::{ArrayLength, GenericArray};
+use digest::{typenum, Digest, OutputSizeUser};
+use merkle_lite::MerkleTree;
+
+const NR_LEAVES: usize = 100_000;
+const NR_LEAVES_CHANGE_DENSE_STEP: usize = NR_LEAVES / 100; // 100 changes total.
+const NR_LEAVES_CHANGE_SPARSE_STEP: usize = NR_LEAVES / 10; //  10 changes total.
+
+benchmark_main!(sha2, sha3);
+
+// With [SHA2] hash functions.
+//
+// [sha2]: https://crates.io/crates/sha3
+benchmark_group!(
+    sha2,
+    tree_get_leaves_mut_all::<typenum::U28, sha2::Sha224>,
+    tree_get_leaves_mut_all::<typenum::U32, sha2::Sha256>,
+    tree_get_leaves_mut_all::<typenum::U48, sha2::Sha384>,
+    tree_get_leaves_mut_all::<typenum::U64, sha2::Sha512>,
+    tree_get_leaves_mut_dense::<typenum::U28, sha2::Sha224>,
+    tree_get_leaves_mut_dense::<typenum::U32, sha2::Sha256>,
+    tree_get_leaves_mut_dense::<typenum::U48, sha2::Sha384>,
+    tree_get_leaves_mut_dense::<typenum::U64, sha2::Sha512>,
+    tree_get_leaves_mut_sparse::<typenum::U28, sha2::Sha224>,
+    tree_get_leaves_mut_sparse::<typenum::U32, sha2::Sha256>,
+    tree_get_leaves_mut_sparse::<typenum::U48, sha2::Sha384>,
+    tree_get_leaves_mut_sparse::<typenum::U64, sha2::Sha512>,
+);
+
+// With [SHA3] hash functions.
+//
+// [sha3]: https://crates.io/crates/sha3
+benchmark_group!(
+    sha3,
+    tree_get_leaves_mut_all::<typenum::U28, sha3::Sha3_224>,
+    tree_get_leaves_mut_all::<typenum::U32, sha3::Sha3_256>,
+    tree_get_leaves_mut_all::<typenum::U48, sha3::Sha3_384>,
+    tree_get_leaves_mut_all::<typenum::U64, sha3::Sha3_512>,
+    tree_get_leaves_mut_dense::<typenum::U28, sha3::Sha3_224>,
+    tree_get_leaves_mut_dense::<typenum::U32, sha3::Sha3_256>,
+    tree_get_leaves_mut_dense::<typenum::U48, sha3::Sha3_384>,
+    tree_get_leaves_mut_dense::<typenum::U64, sha3::Sha3_512>,
+    tree_get_leaves_mut_sparse::<typenum::U28, sha3::Sha3_224>,
+    tree_get_leaves_mut_sparse::<typenum::U32, sha3::Sha3_256>,
+    tree_get_leaves_mut_sparse::<typenum::U48, sha3::Sha3_384>,
+    tree_get_leaves_mut_sparse::<typenum::U64, sha3::Sha3_512>,
+);
+
+fn tree_get_leaves_mut_all<N, B>(b: &mut Bencher)
+where
+    N: ArrayLength<u8>,
+    B: Digest + OutputSizeUser<OutputSize = N>,
+    <N as ArrayLength<u8>>::ArrayType: Copy,
+    <<B as OutputSizeUser>::OutputSize as ArrayLength<u8>>::ArrayType: Copy,
+{
+    tree_get_leaves_mut_step::<N, B>(b, 1);
+}
+
+fn tree_get_leaves_mut_dense<N, B>(b: &mut Bencher)
+where
+    N: ArrayLength<u8>,
+    B: Digest + OutputSizeUser<OutputSize = N>,
+    <N as ArrayLength<u8>>::ArrayType: Copy,
+    <<B as OutputSizeUser>::OutputSize as ArrayLength<u8>>::ArrayType: Copy,
+{
+    tree_get_leaves_mut_step::<N, B>(b, NR_LEAVES_CHANGE_DENSE_STEP);
+}
+
+fn tree_get_leaves_mut_sparse<N, B>(b: &mut Bencher)
+where
+    N: ArrayLength<u8>,
+    B: Digest + OutputSizeUser<OutputSize = N>,
+    <N as ArrayLength<u8>>::ArrayType: Copy,
+    <<B as OutputSizeUser>::OutputSize as ArrayLength<u8>>::ArrayType: Copy,
+{
+    tree_get_leaves_mut_step::<N, B>(b, NR_LEAVES_CHANGE_SPARSE_STEP);
+}
+
+fn tree_get_leaves_mut_step<N, B>(b: &mut Bencher, step: usize)
+where
+    N: ArrayLength<u8>,
+    B: Digest + OutputSizeUser<OutputSize = N>,
+    <N as ArrayLength<u8>>::ArrayType: Copy,
+    <<B as OutputSizeUser>::OutputSize as ArrayLength<u8>>::ArrayType: Copy,
+{
+    let leaves = vec![GenericArray::<u8, N>::default(); NR_LEAVES];
+    let mut tree = MerkleTree::<B>::from_iter(leaves.iter());
+
+    b.iter(|| {
+        {
+            // Calculates the Merkle root with the single leaf change.
+            let mut leaves_mut = tree.get_leaves_mut();
+            for i in (0..NR_LEAVES).step_by(step) {
+                leaves_mut[i] = GenericArray::<u8, N>::default();
+            }
+        }
+        assert_eq!(tree.leaf_len(), NR_LEAVES);
+    })
+}


### PR DESCRIPTION
This improves the Merkle root update through
MerkleLeavesMut in the common operation,
sparsely changes the leave nodes.